### PR TITLE
Added Rotation of vessel & maneuver node

### DIFF
--- a/KerbalSimpit/KerbalSimpitPackets.cs
+++ b/KerbalSimpit/KerbalSimpitPackets.cs
@@ -40,6 +40,7 @@ namespace KerbalSimpit
         public static byte ManeuverData = 34;
         public static byte SASInfo = 35;
         public static byte OrbitInfo = 36;
+        public static byte RotationData = 45;
 
         // Vessel Details
         public static byte ActionGroups = 37;


### PR DESCRIPTION
-added RotationProvider to show current vessel orientation
-modified ManeuverProvider to include rotation of that maneuver node
-called creation and destruction of rotationprovider
-added rotationstruct in outboundhandlers
-modified manueverstruct to add x/y/z rotation
-defined rotationinfo as byte #45 in outbound packets