### PR TITLE
Update AxisControl.cs

### DIFF
--- a/KerbalSimpit/Providers/AxisControl.cs
+++ b/KerbalSimpit/Providers/AxisControl.cs
@@ -72,7 +72,7 @@ namespace KerbalSimPit.Providers
         private SASModeInfoStruct mySASInfo, newSASInfo;
 
         private short myThrottle;
-        private bool lastThrottleSentIsZero = false;
+        private bool lastThrottleSentIsZero = true;
 
         private VesselAutopilot.AutopilotMode mySASMode;
         private Vessel lastActiveVessel;


### PR DESCRIPTION
Fixes the throttle not respecting prelaunch default throttle level from the game settings, when a controller is not connected.