### PR TITLE
Reset PayloadBuffer every time Port is opened or in the event of an overflow

### DIFF
--- a/KerbalSimpit/KSPSerialPort.cs
+++ b/KerbalSimpit/KSPSerialPort.cs
@@ -107,6 +107,9 @@ namespace KerbalSimpit.Serial
                     // If the port connected, set connected status to waiting for the handshake
                     portStatus = ConnectionStatus.WAITING_HANDSHAKE;
 
+                    // Reset buffer (in case port opened/closed multiple times per game session)
+                    CurrentBytesRead = 0;
+
                     SerialReadThread.Start();
                     SerialWriteThread.Start();
                     while (!SerialReadThread.IsAlive || !SerialWriteThread.IsAlive);
@@ -487,6 +490,17 @@ namespace KerbalSimpit.Serial
             {
                 PayloadBuffer[CurrentBytesRead] = ReadBuffer[x];
                 CurrentBytesRead++;
+                if (CurrentBytesRead == PayloadBuffer.Length)
+                {
+                    Debug.LogError("Simpit : PayloadBuffer overflow. Malformed data?");
+                    Debug.LogError("PayloadBuffer: [" + String.Join<byte>(",", PayloadBuffer) + "]");
+
+                    // This may result in some data loss, but that is preferable
+                    // to a buffer overflow. Dropped messages can always be re-sent
+                    // Such an overflow seems very common during handshake
+                    CurrentBytesRead = 0;
+                    return;
+                }
 
                 if (ReadBuffer[x] == 0)
                 {


### PR DESCRIPTION
Running [https://github.com/Simpit-team/KerbalSimpitRevamped-Arduino/blob/main/examples/KerbalSimpitHelloWorld/KerbalSimpitHelloWorld.ino#L34](Simpit-team/KerbalSimpitRevamped-Arduino/blob/main/examples/KerbalSimpitHelloWorld/KerbalSimpitHelloWorld.ino#L34) I often get an IndexOutOfRange exception on handshake and the port status hangs on WAITING_HANDSHAKE.
![image](https://github.com/Simpit-team/KerbalSimpitRevamped/assets/6947647/9c08322f-b368-41e7-a254-2ec9b130de6c)
This does not occur every time, and often only once per Arduino power cycle. Relaunching KSP often fixes it.

That said, it can be a very annoying issue with multiple mods installed and longer game load times. Manually closing and re-opening the port in game does not fix the issue when this occurs. 

After some debugging I've found that, for some reason, the Arduino is sending several messages containing nothing but a single byte value:
![image](https://github.com/Simpit-team/KerbalSimpitRevamped/assets/6947647/0a69f21c-8960-441d-9c3d-9fe9e5774bf2)
The screenshot above demonstrates the contents of 3 incoming messages, followed by a properly formed Handshake. The initial 3 messages contain nothing but the byte 0x47

In my debugging I've seen 3 possible values: 0x7, 0x47, and 0x83. After a quick glance at [https://github.com/Simpit-team/KerbalSimpitRevamped-Arduino/](Simpit-team/KerbalSimpitRevamped-Arduino) I found no obvious cause for this data spam or significance behind the listed byte values.

In these instances KSPSerialPort::RecievedDataEvent never receives a 0x0 byte and thus the overflow is allowed to happen.

Currently, a newly opened port never resets the `CurrentBytesRead` value, which prevents simply closing/re-opening the port from resolving the issue.

----

Changes in this PR will:
1. Ensure CurrentBytesRead gets reset each time a port is opened
2. Reset CurrentBytesRead in the event of a PayloadBuffer overflow, discarding all remaining message contents at that time